### PR TITLE
Allow configuring Liquor using environment variables.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ module "instance_template" {
   subnetwork   = module.liquor_network.subnets[var.region]
   container    = var.container
   machine_type = var.vm_machine_type
+  env          = var.env
 }
 
 resource "google_compute_instance_from_template" "liquor-server" {

--- a/modules/instance-template/main.tf
+++ b/modules/instance-template/main.tf
@@ -36,6 +36,7 @@ module "gce-container" {
   version = "~> 2.0"
 
   container      = {
+    env   = var.env
     image = var.container
   }
   restart_policy = "Always"

--- a/modules/instance-template/variables.tf
+++ b/modules/instance-template/variables.tf
@@ -49,6 +49,12 @@ variable "container" {
   type        = string
 }
 
+variable "env" {
+  description = "Environment variables to set to a VM that runs container."
+  type        = map(string)
+  default     = {}
+}
+
 variable "additional_metadata" {
   type        = map(any)
   description = "Additional metadata to attach to the instance."

--- a/modules/instance-template/variables.tf
+++ b/modules/instance-template/variables.tf
@@ -51,8 +51,8 @@ variable "container" {
 
 variable "env" {
   description = "Environment variables to set to a VM that runs container."
-  type        = map(string)
-  default     = {}
+  type        = list(object({ name = string, value = string }))
+  default     = []
 }
 
 variable "additional_metadata" {

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,6 @@ variable "vm_machine_type" {
 
 variable "env" {
   description = "Environment variables to set for the Liquor server."
-  type        = map(string)
-  default     = {}
+  type        = list(object({ name = string, value = string }))
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "vm_machine_type" {
   type        = string
   default     = "e2-highcpu-2"
 }
+
+variable "env" {
+  description = "Environment variables to set for the Liquor server."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Liquor allows to configure itself using environment variables but the Terraform module doesn't support this yet.

In this PR I added the `env` option to the top-level Terraform module that allows to configure environment variables of the underlying VM that runs the Liquor server.

Partially addresses #3.