### PR TITLE
Define variable to allow setting instance metadata for the module users

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ module "instance_template" {
   container    = var.container
   machine_type = var.vm_machine_type
   env          = var.env
+  additional_metadata = var.metadata
 }
 
 resource "google_compute_instance_from_template" "liquor-server" {

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,8 @@ provider "google" {
 module "liquor_network" {
   source = "./modules/network"
 
-  project  = var.project
-  regions  = tolist([
+  project = var.project
+  regions = tolist([
     var.region
   ])
   vpc_name = "liquor"
@@ -42,13 +42,13 @@ module "liquor_network" {
 module "instance_template" {
   source = "./modules/instance-template"
 
-  project      = var.project
-  region       = var.region
-  network      = module.liquor_network.network
-  subnetwork   = module.liquor_network.subnets[var.region]
-  container    = var.container
-  machine_type = var.vm_machine_type
-  env          = var.env
+  project             = var.project
+  region              = var.region
+  network             = module.liquor_network.network
+  subnetwork          = module.liquor_network.subnets[var.region]
+  container           = var.container
+  machine_type        = var.vm_machine_type
+  env                 = var.env
   additional_metadata = var.metadata
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,9 @@ variable "env" {
   type        = list(object({ name = string, value = string }))
   default     = []
 }
+
+variable "metadata" {
+  type        = map(any)
+  description = "Metadata to attach to the instance."
+  default     = {}
+}


### PR DESCRIPTION
In this PR I added the `metadata` variable to the `spine-liquor` module. This variable will allow users of the component to set their own metadata for the instance running Liquor.

My interest here is that I will be able to set up a startup script for the instance.