### PR TITLE
Allow custom host image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,9 @@ module "instance_template" {
   machine_type        = var.vm_machine_type
   env                 = var.env
   additional_metadata = var.metadata
+  image_project       = var.host_os_image_project
+  image_family        = var.host_os_image_family
+  image_name          = var.host_os_image_name
 }
 
 resource "google_compute_instance_from_template" "liquor-server" {

--- a/modules/instance-template/main.tf
+++ b/modules/instance-template/main.tf
@@ -35,6 +35,10 @@ module "gce-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
 
+  cos_image_family = var.image_family
+  cos_image_name = var.image_name
+  cos_project = local.container_image_project
+
   container      = {
     env   = var.env
     image = var.container

--- a/modules/instance-template/main.tf
+++ b/modules/instance-template/main.tf
@@ -35,10 +35,6 @@ module "gce-container" {
   source  = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
 
-  cos_image_family = var.image_family
-  cos_image_name = var.image_name
-  cos_project = local.container_image_project
-
   container      = {
     env   = var.env
     image = var.container
@@ -77,7 +73,7 @@ module "vm_instance_template" {
   disk_size_gb         = 20
   source_image_project = local.container_image_project
   source_image_family  = var.image_family
-  source_image         = reverse(split("/", module.gce-container.source_image))[0]
+  source_image         = var.image_name
   metadata             = merge(var.additional_metadata, tomap({
     "gce-container-declaration" = module.gce-container.metadata_value,
     "google-logging-enabled"    = "true"

--- a/modules/instance-template/variables.tf
+++ b/modules/instance-template/variables.tf
@@ -62,7 +62,7 @@ variable "additional_metadata" {
 }
 
 variable image_project {
-  description = "The project of the GCE image."
+  description = "The project of the GCE container-optimized image."
   type        = string
   default     = "cos-cloud"
 }
@@ -71,6 +71,12 @@ variable "image_family" {
   description = "The GCE image family to initialize instance template from. The last not-deprecated image is taken."
   type        = string
   default     = "cos-stable"
+}
+
+variable image_name {
+  description = "The GCE container-optimized image to run on the instance."
+  type        = string
+  default     = ""
 }
 
 variable "machine_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "host_os_image_project" {
 }
 
 variable "host_os_image_family" {
-  description = "The image family of the container-optimized images to run on the instance. The last not-deprecated image is taken. "
+  description = "The image family of the container-optimized images to run on the instance. The last not-deprecated image is taken."
   type        = string
   default     = "cos-stable"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,21 @@ variable "metadata" {
   description = "Metadata to attach to the instance."
   default     = {}
 }
+
+variable "host_os_image_project" {
+  description = "The project of the image to run on the instance."
+  type        = string
+  default     = "cos-cloud"
+}
+
+variable "host_os_image_family" {
+  description = "The image family of the container-optimized images to run on the instance. The last not-deprecated image is taken. "
+  type        = string
+  default     = "cos-stable"
+}
+
+variable "host_os_image_name" {
+  description = "The name of the container-optimized image to run on the instance."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
In this PR I added the ability to use a custom image to run the instance.

The main module now exports 3 more optional variables to configure:
`host_os_image_project` - The project of the image to run on the instance.
`host_os_image_family` - The image family of the container-optimized images to run on the instance.
`host_os_image_name` - The name of the container-optimized image to run on the instance.