### PR TITLE
Add the Liquor network to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -30,6 +30,6 @@ output "liquor" {
 }
 
 output "network" {
-  description = "A network created for the Liquor instances"
+  description = "A network created for the Liquor instances."
   value       = module.liquor_network
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,3 +28,8 @@ output "liquor" {
   description = "The name of the created Liquor VM."
   value       = google_compute_instance_from_template.liquor-server.name
 }
+
+output "network" {
+  description = "A network created for the Liquor instances"
+  value       = module.liquor_network
+}


### PR DESCRIPTION
In this PR I added the `liquor-network` created by the module in outputs. This is done to allow users of the module to access the network information and create some other VMs in the same network with Liquor.