### PR TITLE
Add config options for admin service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,16 @@ module "liquor_network" {
   ])
   vpc_name = "liquor"
 }
+locals {
+  adminSettings = [
+    { name = "ADMIN_SERVICE", value = var.admin.enabled },
+    { name = "ADMIN_USERNAME", value = var.admin.login },
+    { name = "ADMIN_PASSWORD", value = var.admin.password },
+    { name = "MICRONAUT_SERVER_PORT", value = var.admin.port },
+  ]
+
+  adminEnv = [for item in local.adminSettings : item if item.value != null]
+}
 
 module "instance_template" {
   source = "./modules/instance-template"
@@ -48,7 +58,7 @@ module "instance_template" {
   subnetwork          = module.liquor_network.subnets[var.region]
   container           = var.container
   machine_type        = var.vm_machine_type
-  env                 = var.env
+  env                 = concat(var.env, local.adminEnv)
   additional_metadata = var.metadata
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "liquor_network" {
   ])
   vpc_name = "liquor"
 }
+
 locals {
   adminSettings = [
     { name = "ADMIN_SERVICE", value = var.admin.enabled },

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,8 @@ module "liquor_network" {
   regions = tolist([
     var.region
   ])
-  vpc_name = "liquor"
+  vpc_name               = "liquor"
+  allow_ingres_tcp_ports = var.admin.port != null ? [var.admin.port] : []
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ module "liquor_network" {
     var.region
   ])
   vpc_name               = "liquor"
-  allow_ingres_tcp_ports = var.admin.port != null ? [var.admin.port] : []
+  allow_ingres_tcp_ports = var.admin.port != null ? [var.admin.port] : [8080]
 }
 
 locals {

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ module "liquor_network" {
 
 locals {
   adminSettings = [
-    { name = "ADMIN_SERVICE", value = var.admin.enabled },
+    { name = "ADMIN_SERVER", value = var.admin.enabled },
     { name = "ADMIN_USERNAME", value = var.admin.login },
     { name = "ADMIN_PASSWORD", value = var.admin.password },
     { name = "MICRONAUT_SERVER_PORT", value = var.admin.port },

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -114,7 +114,7 @@ module "firewall_rules" {
       allow                   = [
         {
           protocol = "tcp"
-          ports    = ["8484", "8080", "8000"]
+          ports    = ["8484"]
         }
       ]
       deny       = []

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -98,8 +98,8 @@ module "firewall_rules" {
           ports    = ["22"]
         }
       ]
-      deny                    = []
-      log_config              = null
+      deny       = []
+      log_config = null
     },
     {
       name                    = "${module.vpc.network_name}-allow-grpc"
@@ -117,8 +117,27 @@ module "firewall_rules" {
           ports    = ["8484", "8080", "8000"]
         }
       ]
-      deny                    = []
-      log_config              = null
+      deny       = []
+      log_config = null
+    },
+    {
+      name                    = "${module.vpc.network_name}-allow-custom"
+      description             = "Allow custom"
+      direction               = "INGRESS"
+      priority                = null
+      ranges                  = null
+      source_tags             = null
+      source_service_accounts = null
+      target_tags             = null
+      target_service_accounts = null
+      allow                   = [
+        {
+          protocol = "tcp"
+          ports    = var.allow_ingres_tcp_ports
+        }
+      ]
+      deny       = []
+      log_config = null
     }
   ]
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -81,7 +81,7 @@ module "firewall_rules" {
   project_id   = var.project
   network_name = module.vpc.network_name
 
-  rules = [
+  rules = concat( [
     {
       name                    = "${module.vpc.network_name}-allow-ssh-ingress"
       description             = "Allow SSH from anywhere."
@@ -119,7 +119,9 @@ module "firewall_rules" {
       ]
       deny       = []
       log_config = null
-    },
+    }
+  ], length(var.allow_ingres_tcp_ports) > 0 ?
+  [
     {
       name                    = "${module.vpc.network_name}-allow-custom"
       description             = "Allow custom"
@@ -139,5 +141,5 @@ module "firewall_rules" {
       deny       = []
       log_config = null
     }
-  ]
+  ] : [])
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -26,27 +26,33 @@
 
 variable "project" {
   description = "The Google Cloud Project ID."
-  type = string
+  type        = string
 }
 
 variable "regions" {
   description = "The set of GCP regions in which to configure subnetworks for GCE VMs."
-  type = set(string)
+  type        = set(string)
 }
 
 variable "vpc_name" {
   description = "The name of VPC to create."
-  type = string
+  type        = string
 }
 
 variable "cidrsubnet_ip_range" {
   description = "IP network address prefix for subnets within VPC. Must be given in CIDR notation."
-  type = string
-  default = "10.128.0.0/16"
+  type        = string
+  default     = "10.128.0.0/16"
 }
 
 variable "cidrsubnet_new_bits" {
   description = "The number of additional bits with which every subnet IP range will extend the prefix."
-  type = number
-  default = 4
+  type        = number
+  default     = 4
+}
+
+variable "allow_ingres_tcp_ports" {
+  description = "Ports that will be added to the firewall exceptions to allow connection over TCP protocol."
+  type        = list(number)
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,7 +68,11 @@ variable "metadata" {
 }
 
 variable "admin" {
-  description = "Configuration for the Admin Server of the Liquor image."
+  description = <<EOT
+    Configuration for the Admin Server of the Liquor image.
+    The guide on how to provide sensitive data to the template and avoid passing it to the VCS:
+    https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables#set-values-with-a-tfvars-file
+  EOT
   sensitive   = true
   type        = object({
     enabled  = bool

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,21 @@ variable "metadata" {
   description = "Metadata to attach to the instance."
   default     = {}
 }
+
+variable "admin" {
+  description = "Configuration for the Admin Server of the Liquor image."
+  sensitive   = true
+  type        = object({
+    enabled  = bool
+    port     = optional(number)
+    login    = optional(string)
+    password = optional(string)
+  })
+  validation {
+    condition     = (var.admin.login != null && var.admin.password != null) || (var.admin.login == null && var.admin.password == null)
+    error_message = "Impossible to set only `login` or `password`, both should be set."
+  }
+  default = {
+    enabled = false
+  }
+}


### PR DESCRIPTION
In this PR I added an ability to config admin service using terraform.

Admin service is an additional service inside the Liquor container that is available over HTTP and allows getting information about current shard states from the Luqior server.

To enable admin service one should provide the `admin {...}` config for the `spine-liquor` module, and set the `enabled` property to `true`.
```Terraform
module "spine-liquor" {

  ...

  admin = {
    enabled = true
  }
}
```

To access the admin server a user should provide valid login and password using HTTP Basic Auth schema. Valid login and password can be configured during deployment using `admin.login` and `admin.password` properties as shown below.
```Terraform
module "spine-liquor" {

  ...

  admin = {
    enabled = true
    login = "j.doe"
    password = "password"
  }
}
```
Shard info is available on `<instance_ip>:<port>/admin/shardInfo` endpoint.

Also it is possible to configure a port on which the admin service will be available, to do so one has to set the `admin.port` property as shown below:
```Terraform
module "spine-liquor" {

  ...

  admin = {
    enabled = true
    port = 9090
  }
}
```