### PR TITLE
0.9.0 Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ module "spine-liquor" {
   admin = {   # Configuration of the Admin server [8].
     enabled = true
     port = 8181   # Port on which the Admin server web interface will be available. Optional parameter. Default is `8181`.
-    login = ""   # Login to the Liquor Admin web interface [9]. Optional parameter.
-    password = ""   # Password to the Liquor Admin web interface [9]. Optional parameter.
+    login = "admin"   # Login to the Liquor Admin web interface [9]. Optional parameter.
+    password = "admin"   # Password to the Liquor Admin web interface [9]. Optional parameter.
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,129 @@ Following the best practices, the Liquor server will reside in its own VPC and r
 
 When working with App Engine applications, consider picking up a region closed to the App Engine
 apps location.
+
+Deployment configuration
+----------
+
+The Liquor module has the following inputs available for configuring the deployment and the server itself:
+
+The complete configuration example may look like this:
+
+Some values that are used several times in the main configuration are declared as Terraform variables in a separate
+`variables.tf` file.
+
+`variables.tf`:
+```terraform
+variable "project" {
+  type = string
+  description = "Identifier of the GCP project where Terraform should perform the deployment."
+  default = ""   # Should be set to your project in which the Liquor will deployed.
+}
+
+variable "region" {
+  type = string
+  description = "GCP region to place resources in."
+  default = ""   # Should be set to the region in which the Liquor will be deployed [1].
+}
+
+variable "zone" {
+  type = string
+  description = "GCP zone to place resources in."
+  default = ""   # Should be set to the zone in which the Liquor will be deployed [1].
+}
+```
+**[1]** To get more info about GCP zones and regions please refer to the [docs][regions-zones].
+
+`liquor.tf`:
+```terraform
+terraform { 
+}
+
+provider "google" {   # Enables the “google” provider.
+  project = var.project   # Refers to the “project” variable in the `variables.tf` file.
+}
+
+provider "google-beta" {   # Enables “google-beta” provider to allow required submodules.
+  project = var.project   # Refers to the “project” variable in the `variables.tf` file.
+}
+
+resource "google_compute_address" "liquor-ip" {   # IP the main application will use to connect to the Liquor server. 
+  name        = "my-liquor-ip"   # Choose the name you'd like.
+  description = "The public static IP address of the Liquor server."
+  region      = var.region   # Refers to the “region” variable in the `variables.tf` file.
+
+  lifecycle {   # Configures the address not to be destroyed and recreated in the future deployments.
+    prevent_destroy = true
+  }
+}
+
+module "spine-liquor" {
+  source     = "SpineEventEngine/spine-liquor/google"
+  version    = "0.9.0"   # Version of the `spine-liquor` Terraform module.
+  project    = var.project   # Refers to the “project” variable in the `variables.tf` file.
+  region     = var.region   # Refers to the “region” variable in the `variables.tf` file.
+  zone       = var.zone   # Refers to the “zone” variable in the `variables.tf` file.
+  container  = "gcr.io/spine-dev/simple-message-delivery-server:v0.9.0"   # A container to be deployed [2].
+  vm_address = google_compute_address.liquor-ip.address   # Refers to the `liquor-ip` resource that 
+                                                          # we've configured in this file above.
+  vm_machine_type = "e2-highcpu-2"   # Type of the GCE instance [3]. Optional parameter.
+  metadata = {}   # Metadata to set to the GCE instance running Liquor [4]. Optional parameter.
+  env        = [   # Environment variables to set to the container [5]. Optional parameter.
+    {
+      name  = "MAX_INBOUND_MESSAGE_SIZE"   # [6].
+      value = "33554432" // 32 MiB
+    },
+    {
+      name  = "SHARD_PROCESSING_TIMEOUT"   # [7].
+      value = "30" // 30 seconds
+    }
+  ]
+  admin = {   # Configuration of the Admin server [8].
+    enabled = true
+    port = 8181   # A port on which the Admin server web interface will be available.
+    login = ""   # Login to the Liquor Admin web interface [9].
+    password = ""   # Password to the Liquor Admin web interface [9].
+  }
+}
+```
+**[2]** There are 2 possible containers to choose from: “simple-server” and “server”. The “simple-server” 
+is the recommended choice, as it supports all latest features and shows better performance in general. 
+The “server” is experimental solution that may undergo a significant changes lately.
+
+**[3]** This parameter allows to set the machine type that will be running the Liquor server. By default, the value
+is set to `e2-highcpu-2`([machine description][e2-machine]) so this parameter may be safely deleted if you don't want 
+to modify it. To get more info on available machine types for GCE instances please refer 
+to the [docs][gce-machine-resource].
+
+**[4]** To get more info on the metadata for GCE instances please refer to the [google platform docs][instance-metadata].
+
+**[5]** The parameter allows to set environment variables to the container (not to the instance running the container),
+those environment variables will be available for the JVM running the Liquor and to the Liquor java application itself.
+Tne parameter is optional and can be safely removed if you don't need to set any environment variables.
+
+**[6]** This environment variable is checked by the Liquor to modify the `gRPC` inbound message size parameter. 
+By default, gRPC allows 4 MB of the max inbound message size. If your payload may exceed this default value
+it's recommended to set a custom value using this parameter. **Pay attention that this feature is only available on 
+the “simple-server” containers starting from the `0.7.3` version.** Setting this environment variable for the container
+that doesn't support this functionality will take no effects.
+
+**[7]** This environment variable is checked by the Liquor and configures the stale shards auto release procedure.
+This procedure allows picking up already occupied shard if one is considered stale. If a gap between a time when
+the shard was picked last time and current time is equal to or more than `SHARD_PROCESSING_TIMEOUT`, the session 
+is considered stale and can be picked up again. The check is performed when a session is asked for picking up. **Pay 
+attention that this feature is only available on the “simple-server” containers starting from the `0.8.3` version.** 
+Setting this environment variable for the container that doesn't support this functionality will take no effects.
+
+**[8]** This block configures the Admin server web interface that allows real-time monitoring of the shard processing
+on the server. By default, this option is disabled. **This feature is available for both “simple-server”  and “server” 
+containers starting from the version `0.8.8`.** Using this setting with containers of lower versions will 
+take no effect.
+
+**[9]** The instruction of how to set sensitive values to the Terraform configuration is available 
+in the [docs][tfvars].
+
+[e2-machine]: https://cloud.google.com/compute/docs/general-purpose-machines#e2_machine_types_table
+[gce-machine-resource]: https://cloud.google.com/compute/docs/machine-resource
+[instance-metadata]: https://cloud.google.com/compute/docs/metadata/overview
+[regions-zones]: https://cloud.google.com/compute/docs/regions-zones
+[tfvars]: https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables#set-values-with-a-tfvars-file

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ module "spine-liquor" {
   ]
   admin = {   # Configuration of the Admin server [8].
     enabled = true
-    port = 8181   # A port on which the Admin server web interface will be available.
-    login = ""   # Login to the Liquor Admin web interface [9].
-    password = ""   # Password to the Liquor Admin web interface [9].
+    port = 8181   # Port on which the Admin server web interface will be available. Optional parameter. Default is `8181`.
+    login = ""   # Login to the Liquor Admin web interface [9]. Optional parameter.
+    password = ""   # Password to the Liquor Admin web interface [9]. Optional parameter.
   }
 }
 ```
@@ -128,8 +128,10 @@ on the server. By default, this option is disabled. **This feature is available 
 containers starting from the version `0.8.8`.** Using this setting with containers of lower versions will 
 take no effect.
 
-**[9]** The instruction of how to set sensitive values to the Terraform configuration is available 
-in the [docs][tfvars].
+**[9]** By default, the `login` and `password` parameters are determined by the deployed container, so please refer 
+to the corresponding container documentation to check what is this values for your container. Even though these 
+parameters are optional and have default values we recommend to set your own `login` and `password`. The instruction 
+of how to set sensitive values to the Terraform configuration is available in the [docs][tfvars].
 
 [e2-machine]: https://cloud.google.com/compute/docs/general-purpose-machines#e2_machine_types_table
 [gce-machine-resource]: https://cloud.google.com/compute/docs/machine-resource

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Some values that are used several times in the main configuration are declared a
 variable "project" {
   type = string
   description = "Identifier of the GCP project where Terraform should perform the deployment."
-  default = ""   # Should be set to your project in which the Liquor will deployed.
+  default = ""   # Should be set to your project in which the Liquor will be deployed.
 }
 
 variable "region" {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Deployment configuration
 
 The Liquor module has the following inputs available for configuring the deployment and the server itself:
 
-The complete configuration example may look like this:
+Below you will find a complete configuration example.
 
 Some values that are used several times in the main configuration are declared as Terraform variables in a separate
 `variables.tf` file.

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/instance-template/main.tf
+++ b/modules/instance-template/main.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/instance-template/outputs.tf
+++ b/modules/instance-template/outputs.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/instance-template/variables.tf
+++ b/modules/instance-template/variables.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/instance-template/versions.tf
+++ b/modules/instance-template/versions.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@
 #
 
 variable "project" {
-  description = "The ID of Google Cloud Project."
+  description = "The ID of Google Cloud Project where the Liquor will be deployed."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,13 @@ variable "vm_machine_type" {
 }
 
 variable "env" {
-  description = "Environment variables to set for the Liquor server."
+  description = <<EOT
+    Environment variables to set for the Liquor server.
+
+    Please pay attention that the effect will depend on the particular image used.
+    As an example the `MAX_INBOUND_MESSAGE_SIZE` and `SHARD_PROCESSING_TIMEOUT` are only accepted by
+    the `simple-server` implementation and will not affect the behaviour of the `server`.
+  EOT
   type        = list(object({ name = string, value = string }))
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2021, TeamDev. All rights reserved.
+# Copyright 2023, TeamDev. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
In this PR I updated the copyright headers and changes the year to `2023`.

Also, I updated the description of the `env` input variable to clarify how this setting will affect different images.

This release is going to be published as `0.9.0` to make it the same as the latest release of the [Liquor](https://github.com/SpineEventEngine/message-delivery) server.