### PR TITLE
Migrate from the deprecated container startup agent to a startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ resource "google_compute_address" "liquor-ip" {   # IP the main application will
 
 module "spine-liquor" {
   source     = "SpineEventEngine/spine-liquor/google"
-  version    = "0.9.0"   # Version of the `spine-liquor` Terraform module.
+  version    = "0.10.0"   # Version of the `spine-liquor` Terraform module.
   project    = var.project   # Refers to the “project” variable in the `variables.tf` file.
   region     = var.region   # Refers to the “region” variable in the `variables.tf` file.
   zone       = var.zone   # Refers to the “zone” variable in the `variables.tf` file.

--- a/main.tf
+++ b/main.tf
@@ -37,10 +37,11 @@ module "liquor_network" {
     var.region
   ])
   vpc_name               = "liquor"
-  allow_ingres_tcp_ports = var.admin.port != null ? [var.admin.port] : [8080]
+  allow_ingres_tcp_ports = local.adminPort != null ? [local.adminPort] : [8080]
 }
 
 locals {
+  adminPort = try(nonsensitive(var.admin.port), null)
   adminSettings = [
     { name = "ADMIN_SERVER", value = var.admin.enabled },
     { name = "ADMIN_USERNAME", value = var.admin.login },

--- a/modules/instance-template/main.tf
+++ b/modules/instance-template/main.tf
@@ -28,20 +28,6 @@ locals {
   container_image_project = var.image_project != "" ? var.image_project : var.project
 }
 
-# Prepares a GCE container image.
-#
-# See https://github.com/terraform-google-modules/terraform-google-container-vm for additional info.
-module "gce-container" {
-  source  = "terraform-google-modules/container-vm/google"
-  version = "~> 2.0"
-
-  container      = {
-    env   = var.env
-    image = var.container
-  }
-  restart_policy = "Always"
-}
-
 data "google_compute_default_service_account" "default" {
   # The default service account of GCE instances
 }
@@ -73,11 +59,14 @@ module "vm_instance_template" {
   disk_size_gb         = 20
   source_image_project = local.container_image_project
   source_image_family  = var.image_family
-  source_image         = reverse(split("/", module.gce-container.source_image))[0]
   metadata             = merge(var.additional_metadata, tomap({
-    "gce-container-declaration" = module.gce-container.metadata_value,
-    "google-logging-enabled"    = "true"
+    "google-logging-enabled" = "true"
   }))
+  startup_script       = templatefile("${path.module}/startup.sh.tftpl", {
+    container_name  = "liquor-server"
+    container_image = var.container
+    environment     = var.env
+  })
 
   # See https://cloud.google.com/security/shielded-cloud/shielded-vm for details.
   enable_shielded_vm       = true

--- a/modules/instance-template/startup.sh.tftpl
+++ b/modules/instance-template/startup.sh.tftpl
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+iptables -A INPUT -j ACCEPT
+iptables -A FORWARD -j ACCEPT
+
 export HOME=/home/appuser
 
 systemctl start docker

--- a/modules/instance-template/startup.sh.tftpl
+++ b/modules/instance-template/startup.sh.tftpl
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-iptables -A INPUT -j ACCEPT
-iptables -A FORWARD -j ACCEPT
-
 export HOME=/home/appuser
 
 systemctl start docker

--- a/modules/instance-template/startup.sh.tftpl
+++ b/modules/instance-template/startup.sh.tftpl
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+iptables -A INPUT -j ACCEPT
+iptables -A FORWARD -j ACCEPT
+
+export HOME=/home/appuser
+
+systemctl start docker
+until docker info >/dev/null 2>&1; do sleep 5; done
+
+docker-credential-gcr configure-docker --registries=gcr.io
+
+docker stop "${container_name}" || true
+docker rm "${container_name}" || true
+
+docker pull "${container_image}"
+
+docker run \
+  --name "${container_name}" \
+  --network host \
+%{ for entry in environment ~}
+  -e '${entry.name}=${replace(entry.value, "'", "'\"'\"'")}' \
+%{ endfor ~}
+  --restart=always \
+  -d "${container_image}"

--- a/modules/instance-template/startup.sh.tftpl
+++ b/modules/instance-template/startup.sh.tftpl
@@ -4,7 +4,18 @@ set -e
 export HOME=/home/appuser
 
 systemctl start docker
-until docker info >/dev/null 2>&1; do sleep 5; done
+docker_wait_timeout_secs=120
+docker_wait_sleep_secs=5
+docker_wait_elapsed_secs=0
+until docker info >/dev/null 2>&1; do
+  if [ "$docker_wait_elapsed_secs" -ge "$docker_wait_timeout_secs" ]; then
+    echo "Docker did not become ready within ${docker_wait_timeout_secs} seconds." >&2
+    systemctl status docker --no-pager || true
+    exit 1
+  fi
+  sleep "$docker_wait_sleep_secs"
+  docker_wait_elapsed_secs=$((docker_wait_elapsed_secs + docker_wait_sleep_secs))
+done
 
 docker-credential-gcr configure-docker --registries=gcr.io
 

--- a/modules/instance-template/startup.sh.tftpl
+++ b/modules/instance-template/startup.sh.tftpl
@@ -9,7 +9,7 @@ docker_wait_sleep_secs=5
 docker_wait_elapsed_secs=0
 until docker info >/dev/null 2>&1; do
   if [ "$docker_wait_elapsed_secs" -ge "$docker_wait_timeout_secs" ]; then
-    echo "Docker did not become ready within ${docker_wait_timeout_secs} seconds." >&2
+    echo "Docker did not become ready within $${docker_wait_timeout_secs} seconds." >&2
     systemctl status docker --no-pager || true
     exit 1
   fi


### PR DESCRIPTION
This PR addresses a GCP [deprecation](https://docs.cloud.google.com/compute/docs/containers/migrate-containers) by switching the `gce-container` declaration to a startup script.

### Other changes

* Fixed how `var.admin.port` is handled for compatibility with newer Terraform versions.